### PR TITLE
fix(ai-clis): tolerate CodeRabbit installer's spurious non-zero exit

### DIFF
--- a/src/ai-clis/install.sh
+++ b/src/ai-clis/install.sh
@@ -104,7 +104,16 @@ fi
 # CodeRabbit CLI
 if [ "${CODERABBIT}" = "true" ]; then
     echo "Installing CodeRabbit CLI..."
-    curl -fsSL https://cli.coderabbit.ai/install.sh | CODERABBIT_INSTALL_DIR=/usr/local/bin sh
+    # The upstream installer can exit non-zero even after a successful install
+    # (it prints "Installation complete" then returns exit code 2), which would
+    # abort this script under `set -e`. Tolerate the exit code and verify the
+    # binary actually landed instead.
+    curl -fsSL https://cli.coderabbit.ai/install.sh | CODERABBIT_INSTALL_DIR=/usr/local/bin sh || true
+    if [ -x /usr/local/bin/coderabbit ] || command -v coderabbit >/dev/null 2>&1; then
+        echo "CodeRabbit CLI installed."
+    else
+        echo "Warning: CodeRabbit CLI installation failed"
+    fi
 fi
 
 # Beads - coding agent memory system (depends on Dolt)


### PR DESCRIPTION
## Context

The new scheduled validation (PR #63) immediately caught that `ai-clis` is broken on `main`: the upstream CodeRabbit installer prints `[SUCCESS] Installation complete`, verifies the binary, then **exits with code 2**. Under `set -e` that aborts the entire `ai-clis` feature build before later installers (Dolt/Beads, Specify, QMD, Claude Agent ACP) even run.

Tracked in #64 (daily run [27483832819](https://github.com/get2knowio/devcontainer-features/actions/runs/27483832819)).

## Fix

Cherry-pick of `69592a7` (originally authored on the unmerged `001-agentsh-feature` branch, never reached `main`). Tolerates the installer's exit code and verifies the binary landed instead — matching the warning-on-failure pattern already used for Claude Code and Specify CLI. Only `src/ai-clis/install.sh` changes.

This PR touches `src/**`, so the test workflow runs here and exercises `ai-clis` end-to-end before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)