### PR TITLE
test: pin Ubuntu base image to base:ubuntu-24.04 in scenarios and CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,8 +49,8 @@ jobs:
           fi
           echo "tier=$tier" >> "$GITHUB_OUTPUT"
 
-          full_autogen='{"include":[{"feature":"ai-clis","baseImage":"mcr.microsoft.com/devcontainers/javascript-node:22"},{"feature":"modern-cli-tools","baseImage":"mcr.microsoft.com/devcontainers/base:ubuntu"},{"feature":"node-dev-tools","baseImage":"mcr.microsoft.com/devcontainers/javascript-node:22"},{"feature":"rust-dev-tools","baseImage":"mcr.microsoft.com/devcontainers/rust:latest"},{"feature":"github-actions-tools","baseImage":"mcr.microsoft.com/devcontainers/base:ubuntu"},{"feature":"python-tools","baseImage":"mcr.microsoft.com/devcontainers/python:latest"}]}'
-          daily_autogen='{"include":[{"feature":"ai-clis","baseImage":"mcr.microsoft.com/devcontainers/javascript-node:22"},{"feature":"modern-cli-tools","baseImage":"mcr.microsoft.com/devcontainers/base:ubuntu"}]}'
+          full_autogen='{"include":[{"feature":"ai-clis","baseImage":"mcr.microsoft.com/devcontainers/javascript-node:22"},{"feature":"modern-cli-tools","baseImage":"mcr.microsoft.com/devcontainers/base:ubuntu-24.04"},{"feature":"node-dev-tools","baseImage":"mcr.microsoft.com/devcontainers/javascript-node:22"},{"feature":"rust-dev-tools","baseImage":"mcr.microsoft.com/devcontainers/rust:latest"},{"feature":"github-actions-tools","baseImage":"mcr.microsoft.com/devcontainers/base:ubuntu-24.04"},{"feature":"python-tools","baseImage":"mcr.microsoft.com/devcontainers/python:latest"}]}'
+          daily_autogen='{"include":[{"feature":"ai-clis","baseImage":"mcr.microsoft.com/devcontainers/javascript-node:22"},{"feature":"modern-cli-tools","baseImage":"mcr.microsoft.com/devcontainers/base:ubuntu-24.04"}]}'
           full_scenarios='["ai-clis","modern-cli-tools","node-dev-tools","rust-dev-tools","github-actions-tools","python-tools"]'
           daily_scenarios='["ai-clis","modern-cli-tools"]'
 

--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -1,6 +1,6 @@
 {
     "all_features": {
-        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
         "features": {
             "ghcr.io/devcontainers/features/python:1": {},
             "ghcr.io/devcontainers/features/node:1": {},

--- a/test/ai-clis/scenarios.json
+++ b/test/ai-clis/scenarios.json
@@ -1,6 +1,6 @@
 {
     "claude_only": {
-        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
         "features": {
             "ghcr.io/devcontainers/features/node:1": {},
             "ai-clis": {
@@ -9,7 +9,7 @@
         }
     },
     "npm_tools_only": {
-        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
         "features": {
             "ghcr.io/devcontainers/features/node:1": {},
             "ai-clis": {

--- a/test/github-actions-tools/scenarios.json
+++ b/test/github-actions-tools/scenarios.json
@@ -1,6 +1,6 @@
 {
     "act_only": {
-        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
         "features": {
             "github-actions-tools": {
                 "install": "act"
@@ -8,7 +8,7 @@
         }
     },
     "actionlint_only": {
-        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
         "features": {
             "github-actions-tools": {
                 "install": "actionlint"

--- a/test/modern-cli-tools/scenarios.json
+++ b/test/modern-cli-tools/scenarios.json
@@ -1,6 +1,6 @@
 {
     "minimal": {
-        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
         "features": {
             "modern-cli-tools": {
                 "install": "bat,ripgrep"
@@ -8,7 +8,7 @@
         }
     },
     "omit_neovim": {
-        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
         "features": {
             "modern-cli-tools": {
                 "omit": "neovim"

--- a/test/node-dev-tools/scenarios.json
+++ b/test/node-dev-tools/scenarios.json
@@ -1,6 +1,6 @@
 {
     "typescript_only": {
-        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
         "features": {
             "ghcr.io/devcontainers/features/node:1": {},
             "node-dev-tools": {
@@ -9,7 +9,7 @@
         }
     },
     "no_bun": {
-        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
         "features": {
             "ghcr.io/devcontainers/features/node:1": {},
             "node-dev-tools": {

--- a/test/python-tools/scenarios.json
+++ b/test/python-tools/scenarios.json
@@ -1,6 +1,6 @@
 {
     "poetry_only": {
-        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
         "features": {
             "ghcr.io/devcontainers/features/python:1": {},
             "python-tools": {

--- a/test/rust-dev-tools/scenarios.json
+++ b/test/rust-dev-tools/scenarios.json
@@ -1,6 +1,6 @@
 {
     "bacon_only": {
-        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
         "features": {
             "ghcr.io/devcontainers/features/rust:1": {},
             "rust-dev-tools": {


### PR DESCRIPTION
## Context

The full-tier run on #65 showed `test-global` failing — not on one of our features, but on the upstream `ghcr.io/devcontainers/features/node` feature:

```
W: OpenPGP signature verification failed: ... resolute InRelease:
   Could not execute 'gpgv' to verify signature (is gnupg installed?)
ERROR: Feature "Node.js (via nvm)..." failed to install! ... exit code: 100
```

The rolling `mcr.microsoft.com/devcontainers/base:ubuntu` tag has floated to the non-LTS interim release **"resolute"**, whose base image ships without `gnupg`/`gpgv`, breaking apt signature verification (and thus the upstream node feature) in the composition test.

## Fix

Pin `base:ubuntu` → `base:ubuntu-24.04` (LTS) across all feature test scenarios and the autogenerated `--base-image` matrix in `test.yaml`. `base:debian` is left unchanged.

This mirrors `7d18d88` (authored on the unmerged `001-agentsh-feature` branch), adapted to main's current `test.yaml` (base images now live in the `setup` job's matrix JSON) and excluding `test/agentsh` (not on main).

This PR touches `test/**`, so the test workflow runs here and exercises `test-global` end-to-end before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)