### PR TITLE
test: source Node from base image in test-global, drop flaky upstream node feature

### DIFF
--- a/test/_global/scenarios.json
+++ b/test/_global/scenarios.json
@@ -1,9 +1,8 @@
 {
     "all_features": {
-        "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+        "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
         "features": {
             "ghcr.io/devcontainers/features/python:1": {},
-            "ghcr.io/devcontainers/features/node:1": {},
             "ghcr.io/devcontainers/features/rust:1": {},
             "ai-clis": {},
             "modern-cli-tools": {},


### PR DESCRIPTION
## Context

After pinning the base image (#66), `test-global` still failed — the upstream `ghcr.io/devcontainers/features/node` feature aborts during its `apt-get update`:

```
W: GPG error: ... noble InRelease: Couldn't create temporary file
   /tmp/apt.conf.X for passing config to apt-key
ERROR: Feature "Node.js (via nvm)..." failed to install! ... exit code: 100
```

Investigation:
- **Not disk pressure** — a `df -h` probe showed the runner had ~89G free.
- **Not our scripts** — static analysis confirms no feature of ours touches `/tmp`, the apt sandbox, `TMPDIR`, or adds apt repos/keys.
- **Not node-on-noble in general** — `test-scenarios (ai-clis)` layers `node:1` on the same `base:ubuntu-24.04` and passes.

It only fails in the full 9-feature composition: the apt `_apt` sandbox user can't write `/tmp` during the upstream node feature's update. This is an upstream node-feature interaction in the large build, not a defect in our features.

## Fix

Source Node from the `javascript-node:22` base image and drop the upstream `node` feature, keeping `python` and `rust` (which our `*-dev-tools` features genuinely need via `installsAfter`). The composition stays meaningful for *our* features while removing the flaky upstream component.

(Supersedes the earlier disk-space approach on this branch, which the `df` probe disproved.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)