### PR TITLE
fix(modern-cli-tools): stop jj install from stripping /tmp permissions

### DIFF
--- a/src/modern-cli-tools/install.sh
+++ b/src/modern-cli-tools/install.sh
@@ -191,9 +191,14 @@ if [ "${JUJUTSU}" = "true" ]; then
     esac
     JJ_URL="https://github.com/jj-vcs/jj/releases/download/v${JUJUTSUVERSION}/jj-v${JUJUTSUVERSION}-${JJ_ARCH}-unknown-linux-musl.tar.gz"
     curl -fsSL "$JJ_URL" -o /tmp/jj.tgz
-    tar -xzf /tmp/jj.tgz -C /tmp
-    install /tmp/jj /usr/local/bin/jj
-    rm -f /tmp/jj.tgz /tmp/jj
+    # The jj tarball has a top-level "./" entry; extracting it straight into
+    # /tmp would apply that entry's 0755 mode to /tmp itself, stripping the
+    # 1777 sticky bit and breaking apt's _apt sandbox for anything installed
+    # afterward. Extract into a dedicated throwaway dir instead.
+    mkdir -p /tmp/jj-extract
+    tar -xzf /tmp/jj.tgz -C /tmp/jj-extract
+    install /tmp/jj-extract/jj /usr/local/bin/jj
+    rm -rf /tmp/jj.tgz /tmp/jj-extract
 fi
 
 # zellij


### PR DESCRIPTION
## Root cause

The `test-global` composition test was failing because an upstream language feature (node, then python after I tried reordering) aborted during `apt-get` with:

```
Unable to mkstemp /tmp/apt.sig.X - GetTempFile (13: Permission denied)
Couldn't create temporary file /tmp/apt.conf.X for passing config to apt-key
ERROR: Feature "..." failed to install! ... exit code: 100
```

After ruling out disk pressure (89G free), base-image drift (fixed in #66), and any `/tmp`/`umask`/`containerEnv` manipulation in our scripts, I traced it to the **jujutsu install in `modern-cli-tools`**:

```sh
tar -xzf /tmp/jj.tgz -C /tmp        # jj tarball has a top-level "./" entry
```

The jj tarball contains a `./` directory member with mode `0755`. GNU/busybox tar applies that member's mode to the **extraction target** — here `/tmp` itself — resetting it from `1777` to `0755`. That strips the sticky + world-writable bits, so the unprivileged `_apt` sandbox user in any feature layered afterward can't create temp files in `/tmp`.

Confirmed in a container:

```
Before:                1777 /tmp
After jj full extract:  755 /tmp   <-- bug
After fixed extract:   1777 /tmp   <-- fixed, jj 0.42.0 still installs
```

This is a real bug, not just a test artifact: any apt-based feature (or user workflow) layered after `modern-cli-tools` would hit it.

## Fix

Extract into a dedicated `/tmp/jj-extract` throwaway dir so the tarball's `./` mode lands there instead of on `/tmp` — matching the pattern already used for `ast-grep`. Other tarball installs in this file are unaffected: lazygit/zellij/starship/act/actionlint name a specific member, and eza targets `/usr/local/bin` (where `755` is benign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)