### PR TITLE
ci: make test-global a blocking job so failures alert

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,9 +113,12 @@ jobs:
     needs: setup
     # The all-features composition test is broad; skip it on the daily
     # high-risk tier and keep it on full runs (weekly / push / PR / dispatch).
+    # It is a blocking job like the others: a failure marks the run red (so PR
+    # authors catch composition breakage) and surfaces to notify-on-failure on
+    # scheduled/dispatched runs. (It cannot be continue-on-error, or its result
+    # would report as success to the notify gate and never alert.)
     if: needs.setup.outputs.tier != 'daily'
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Context

`test-global` was `continue-on-error: true`, which forces its `result` to report as `success` to the `notify-on-failure` gate even when it fails. Two consequences:
- a scheduled composition breakage would **never** open an `installer-breakage` issue, and
- a PR author who broke the composition would see a **green** check.

Now that the `/tmp`-permission root cause is fixed (#68) and `test-global` passes reliably, treat it as a blocking job like every other test job.

## Change

Remove `continue-on-error: true` from `test-global`. A failure now marks the run red (PR authors catch their own composition breakage) and surfaces to `notify-on-failure` on scheduled/dispatched runs.

No `notify-on-failure` changes needed — it already lists `test-global` in `needs` and filters on `result == 'failure'` (the same path that opened issue #64 when `test-autogenerated` failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)