### PR TITLE
fix(modern-cli-tools): pin eza --icons=auto so aliases accept path args

### DIFF
--- a/src/modern-cli-tools/install.sh
+++ b/src/modern-cli-tools/install.sh
@@ -239,9 +239,11 @@ fi
 ZSHRC="$_REMOTE_USER_HOME/.zshrc"
 
 if [ "${EZA}" = "true" ]; then
-    echo 'alias ls="eza --icons"' >> "$ZSHRC"
-    echo 'alias ll="eza -l --icons"' >> "$ZSHRC"
-    echo 'alias la="eza -la --icons"' >> "$ZSHRC"
+    # --icons takes an optional value (eza >= 0.15.0), so attach it with '='
+    # or a following path argument gets swallowed as the flag's value.
+    echo 'alias ls="eza --icons=auto"' >> "$ZSHRC"
+    echo 'alias ll="eza -l --icons=auto"' >> "$ZSHRC"
+    echo 'alias la="eza -la --icons=auto"' >> "$ZSHRC"
 fi
 
 if [ "${ZOXIDE}" = "true" ]; then

--- a/test/modern-cli-tools/test.sh
+++ b/test/modern-cli-tools/test.sh
@@ -16,4 +16,11 @@ check "jujutsu installed" bash -c "command -v jj"
 check "zellij installed" bash -c "command -v zellij"
 check "starship installed" bash -c "command -v starship"
 
+# The eza aliases must still work when given a path argument. '--icons' takes an
+# optional value in eza >= 0.15.0, so an unattached value swallows the path.
+touch /tmp/eza-alias-probe.txt
+check "ls alias accepts a path argument" zsh -ic "ls /tmp/eza-alias-probe.txt"
+check "ll alias accepts a path argument" zsh -ic "ll /tmp/eza-alias-probe.txt"
+check "la alias accepts a path argument" zsh -ic "la /tmp/eza-alias-probe.txt"
+
 reportResults


### PR DESCRIPTION
Fixes #72

## Problem

The `ls`/`ll`/`la` aliases written by `modern-cli-tools` break as soon as a path argument is passed:

```
$ ls /tmp/foo.tar.gz
error: invalid value '/tmp/foo.tar.gz' for '--icons [<WHEN>]'
  [possible values: always, auto, never]
```

Since eza 0.15.0, `--icons` takes an *optional* value (`always|auto|never`), so clap consumes the following bare token as the flag's value instead of treating it as a path. Bare `ls` works, which is why this hid for a while. The feature defaults `ezaVersion` to `latest`, so every container built from it is affected.

## Fix

Attach the value with `=` so it can't absorb the next argument. `auto` matches eza's own default — icons in a TTY, suppressed when piped.

```diff
-echo 'alias ls="eza --icons"' >> "$ZSHRC"
+echo 'alias ls="eza --icons=auto"' >> "$ZSHRC"
```

## Test coverage

`test/modern-cli-tools/test.sh` only checked `command -v eza`, so it never exercised the aliases. Added three checks that source the user's `.zshrc` via an interactive zsh and run each alias against a real file — these fail on `main` and pass here.

## Verification

Confirmed the behavior directly against eza v0.23.5:

- `eza --icons /etc/hosts` → exit 2, `invalid value '/etc/hosts' for '--icons [<WHEN>]'`
- `eza --icons=auto /etc/hosts` → exit 0

## Scope

No change needed in `get2knowio/devcontainer-templates`. All four templates consume this feature via the floating `modern-cli-tools:2` tag and define no aliases of their own, so they pick the fix up on the next container build once this releases as a patch bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)