### PR TITLE
fix(ai-clis): install specify-cli from PyPI instead of git HEAD

### DIFF
--- a/src/ai-clis/README.md
+++ b/src/ai-clis/README.md
@@ -1,6 +1,23 @@
 # AI CLI Tools (ai-clis)
 
-Installs AI coding assistant CLIs and agentic development tools: Claude Code, Gemini CLI, OpenAI Codex, GitHub Copilot, OpenCode, CodeRabbit, Beads (with Dolt), and Specify CLI.
+Installs AI coding assistant CLIs and agentic development tools: Claude Code, Gemini CLI, OpenAI Codex, GitHub Copilot, OpenCode, CodeRabbit, Beads (with Dolt), Specify CLI, QMD, and Claude Agent ACP.
+
+## Tools
+
+`install` and `omit` take these identifiers:
+
+| Identifier | Tool |
+|------------|------|
+| `claudeCode` | Claude Code |
+| `geminiCli` | Gemini CLI |
+| `codex` | OpenAI Codex |
+| `copilot` | GitHub Copilot |
+| `openCode` | OpenCode |
+| `codeRabbit` | CodeRabbit |
+| `beads` | Beads (installs Dolt as a dependency) |
+| `specifyCli` | Specify CLI (spec-kit) |
+| `qmd` | QMD |
+| `claudeAgentAcp` | Claude Agent ACP |
 
 ## Options
 

--- a/src/ai-clis/install.sh
+++ b/src/ai-clis/install.sh
@@ -142,7 +142,10 @@ if [ "${SPECIFYCLI}" = "true" ]; then
     fi
     # Ensure ~/.local/bin on PATH for user-installed tools
     echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$_REMOTE_USER_HOME/.zshrc"
-    su - "$_REMOTE_USER" -c "\"$UV_BIN\" tool install specify-cli --from git+https://github.com/github/spec-kit.git" || echo "Warning: Specify CLI installation failed"
+    # Install from PyPI rather than git. `--from git+...` with no `@vX.Y.Z` ref
+    # builds the default branch, so every image picked up unreleased HEAD and two
+    # builds a day apart could differ. PyPI tracks tagged releases instead.
+    su - "$_REMOTE_USER" -c "\"$UV_BIN\" tool install specify-cli" || echo "Warning: Specify CLI installation failed"
 fi
 
 # QMD - on-device search engine for markdown notes and documents

--- a/test/ai-clis/test.sh
+++ b/test/ai-clis/test.sh
@@ -11,6 +11,8 @@ check "coderabbit installed" bash -c "command -v coderabbit"
 check "dolt installed" bash -c "command -v dolt"
 check "beads installed" bash -c "command -v bd"
 check "specify installed" bash -c "command -v specify"
+# Runs the binary, not just PATH lookup — a git-HEAD build can land and be broken.
+check "specify reports a version" bash -c "specify --version"
 check "qmd installed" bash -c "command -v qmd"
 check "claude-agent-acp installed" bash -c "command -v claude-agent-acp"
 


### PR DESCRIPTION
## Problem

`src/ai-clis/install.sh` installed Specify CLI straight off the repo's default branch:

```sh
uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
```

With no `@vX.Y.Z` ref, uv resolves `main`. So every image built from this feature got **unreleased** code — `main` is currently 3 commits past `v0.15.1` — and two builds a day apart could ship different Specify versions with no change on our side. The feature exposes no version option either, so users couldn't pin it.

Upstream's README documents the git form only *with* an explicit tag: "Replace `vX.Y.Z` with the latest release tag from Releases".

## Fix

`specify-cli` is published to PyPI, currently 0.15.1 — the same as the latest GitHub release. Dropping `--from` tracks tagged releases and matches how every other tool in this feature installs (latest from npm or a vendor installer, no version knobs).

```diff
-uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
+uv tool install specify-cli
```

Verified in a clean `python:3.12-slim` container:

```
$ uv tool install specify-cli && specify --version
specify 0.15.1
```

## Also in this PR

- **Test**: added `specify --version` next to the existing `command -v specify`, so the check exercises the binary rather than just a PATH lookup.
- **Docs**: the README intro never picked up QMD or Claude Agent ACP (the feature's own `description` already lists them). Added those, plus a table of the `install`/`omit` identifiers — `qmd` and `claudeAgentAcp` were previously only discoverable by reading `install.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)