### PR TITLE
chore(ai-clis): order after uv-providing features

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,3 +16,6 @@ jobs:
         uses: devcontainers/action@v1
         with:
           validate-only: "true"
+          # Without this the action scandirs '' and crashes with ENOENT before
+          # reading any metadata. release.yaml passes the same path to publish.
+          base-path-to-features: "./src"

--- a/src/ai-clis/README.md
+++ b/src/ai-clis/README.md
@@ -69,3 +69,5 @@ Use `install` to list exactly the CLIs you need — new CLIs added in future rel
 ```
 
 **Requires:** Node.js (installs after `ghcr.io/devcontainers/features/node`)
+
+**uv:** `specifyCli` installs via [uv](https://docs.astral.sh/uv/). This feature installs uv itself if it isn't already present, so no extra feature is required. If you do include a uv-providing feature — this repo's `python-tools`, or one of the community `uv` features — it is ordered first via `installsAfter` and reused, avoiding a duplicate install.

--- a/src/ai-clis/devcontainer-feature.json
+++ b/src/ai-clis/devcontainer-feature.json
@@ -17,6 +17,10 @@
     }
   },
   "installsAfter": [
-    "ghcr.io/devcontainers/features/node"
+    "ghcr.io/devcontainers/features/node",
+    "ghcr.io/get2knowio/devcontainer-features/python-tools",
+    "ghcr.io/va-h/devcontainers-features/uv",
+    "ghcr.io/jsburckhardt/devcontainer-features/uv",
+    "ghcr.io/gvatsal60/dev-container-features/uv"
   ]
 }


### PR DESCRIPTION
## Context

`specifyCli` installs via uv, and `install.sh:130-142` self-provisions uv when it's absent (`command -v uv` → `~/.local/bin/uv` → Astral installer). So the feature works standalone — this is not a missing dependency.

The gap is ordering. This repo's `python-tools` feature *also* installs uv to `/usr/local/bin/uv`, and nothing sequenced the two. If `ai-clis` happened to run first, it ran the Astral installer, and `python-tools` then overwrote that uv. No breakage, but a duplicated download and a nondeterministic build.

## Why `installsAfter` and not `dependsOn`

Per the [Features spec](https://containers.dev/implementors/features/), `dependsOn` is a hard dependency: the resolver auto-installs it recursively and fails the whole container build if it can't be satisfied. Neither `dependsOn` nor `installsAfter` can be conditioned on option values.

Since `specifyCli` is one of ten optional installs, `dependsOn` would force uv into every container using `ai-clis` — including ones passing `omit: "specifyCli"` or `install: "claudeCode"` that never touch Python. `installsAfter` only reorders features the user already selected and is inert otherwise, which matches the real relationship.

## Change

```jsonc
"installsAfter": [
  "ghcr.io/devcontainers/features/node",
  "ghcr.io/get2knowio/devcontainer-features/python-tools",
  "ghcr.io/va-h/devcontainers-features/uv",
  "ghcr.io/jsburckhardt/devcontainer-features/uv",
  "ghcr.io/gvatsal60/dev-container-features/uv"
]
```

The three community uv features are the ones listed on containers.dev; `va-h` is additionally confirmed against GHCR (the repo has `src/uv` and the registry issues a pull token for it). Unused entries are no-ops, so listing all three only helps.

Also documented the uv relationship in the README.

## Risk

Metadata and docs only — no install logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)